### PR TITLE
Add post highlighting from activity pages

### DIFF
--- a/ui/static/css/user.css
+++ b/ui/static/css/user.css
@@ -400,6 +400,12 @@ body {
     box-shadow: 0 0 10px rgba(251, 113, 133, 0.4);
 }
 
+/* Highlight entire post container when navigated via "My Posts" or similar */
+.highlight-post {
+    border-color: var(--color-warning);
+    box-shadow: 0 0 10px rgba(251, 113, 133, 0.4);
+}
+
 .comment:hover {
     border-left-color: var(--color-primary);
     box-shadow: inset 0 0 18px rgba(139, 92, 246, 0.15),

--- a/ui/static/js/user/user_created_posts.js
+++ b/ui/static/js/user/user_created_posts.js
@@ -64,7 +64,7 @@ function renderCreatedPosts(posts) {
       .parentNode.appendChild(commentContainer);
 
     const wrapper = document.createElement('a');
-    wrapper.href = `/user/post?id=${post.id}`;
+    wrapper.href = `/user/post?id=${post.id}&highlightPost=1`;
     wrapper.className = 'post-link';
     wrapper.appendChild(node);
 

--- a/ui/static/js/user/user_my_comments.js
+++ b/ui/static/js/user/user_my_comments.js
@@ -31,7 +31,7 @@ function render(comments) {
     node.querySelector('.comment-content').textContent = c.content;
     node.querySelector('.comment-time').textContent = new Date(c.created_at).toLocaleString();
     const wrapper = document.createElement('a');
-    wrapper.href = `/user/post?id=${c.post_id}&highlight=${c.id}`;
+    wrapper.href = `/user/post?id=${c.post_id}&highlight=${c.id}&highlightPost=1`;
     wrapper.className = 'post-link';
     wrapper.appendChild(node);
     container.appendChild(wrapper);

--- a/ui/static/js/user/user_my_posts.js
+++ b/ui/static/js/user/user_my_posts.js
@@ -64,7 +64,7 @@ function renderCreatedPosts(posts) {
       .parentNode.appendChild(commentContainer);
 
     const wrapper = document.createElement('a');
-    wrapper.href = `/user/post?id=${post.id}`;
+    wrapper.href = `/user/post?id=${post.id}&highlightPost=1`;
     wrapper.className = 'post-link';
     wrapper.appendChild(node);
 

--- a/ui/static/js/user/user_post.js
+++ b/ui/static/js/user/user_post.js
@@ -1,6 +1,7 @@
 const params = new URLSearchParams(window.location.search);
 const postId = params.get('id');
 const highlightId = params.get('highlight');
+const highlightPost = params.get('highlightPost') === '1';
 const lastReactions = new Map(); // key = `${type}:${id}`, value = 1 (like) or 2 (dislike)
 
 
@@ -256,6 +257,10 @@ function renderSinglePost(post) {
   // Create a boxed post container
   const postBox = document.createElement('div');
   postBox.className = 'post';
+  if (highlightPost) {
+    postBox.classList.add('highlight-post');
+    setTimeout(() => postBox.scrollIntoView({ behavior: 'smooth', block: 'center' }), 0);
+  }
 
   postBox.appendChild(title);
   postBox.appendChild(meta);


### PR DESCRIPTION
## Summary
- add `.highlight-post` style to highlight a post container
- highlight posts when URL has `highlightPost=1`
- include the `highlightPost` flag when linking from activity pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68823fd869ec8324a5be094089d6e171