### PR TITLE
Add post editing page and backend update endpoint

### DIFF
--- a/API/handlers/post_handler.go
+++ b/API/handlers/post_handler.go
@@ -34,24 +34,24 @@ func (h *PostHandler) CreatePost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-    CategoryIDs []int  `json:"category_ids"` // Instead of CategoryID
-    Title       string `json:"title"`
-    Content     string `json:"content"`
-}
+		CategoryIDs []int  `json:"category_ids"` // Instead of CategoryID
+		Title       string `json:"title"`
+		Content     string `json:"content"`
+	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		utils.ErrorResponse(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
 	if len(req.CategoryIDs) == 0 || req.Title == "" || req.Content == "" {
-    utils.ErrorResponse(w, "At least one category, title and content are required", http.StatusBadRequest)
-    return
-}
+		utils.ErrorResponse(w, "At least one category, title and content are required", http.StatusBadRequest)
+		return
+	}
 
 	post := models.Post{
-		UserID:     user.ID,
-		Title:      req.Title,
-		Content:    req.Content,
+		UserID:  user.ID,
+		Title:   req.Title,
+		Content: req.Content,
 	}
 
 	created, err := h.PostRepo.Create(post, req.CategoryIDs)
@@ -61,4 +61,46 @@ func (h *PostHandler) CreatePost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.JSONResponse(w, created, http.StatusCreated)
+}
+
+// UpdatePost allows the author to update the title or content of an existing post
+func (h *PostHandler) UpdatePost(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		utils.ErrorResponse(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	user := middleware.GetCurrentUser(r)
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req struct {
+		PostID  string  `json:"post_id"`
+		Title   *string `json:"title,omitempty"`
+		Content *string `json:"content,omitempty"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		utils.ErrorResponse(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.PostID == "" {
+		utils.ErrorResponse(w, "Post ID required", http.StatusBadRequest)
+		return
+	}
+
+	if req.Title == nil && req.Content == nil {
+		utils.ErrorResponse(w, "No fields to update", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.PostRepo.Update(req.PostID, user.ID, req.Title, req.Content); err != nil {
+		utils.ErrorResponse(w, "Failed to update post", http.StatusInternalServerError)
+		return
+	}
+
+	utils.JSONResponse(w, map[string]string{"status": "ok"}, http.StatusOK)
 }

--- a/API/repository/post_repository.go
+++ b/API/repository/post_repository.go
@@ -2,6 +2,8 @@ package repository
 
 import (
 	"database/sql"
+	"fmt"
+	"strings"
 	"time"
 
 	"forum/models"
@@ -218,6 +220,28 @@ func (r *PostRepository) GetPostsReactedByUser(userID string) ([]models.PostWith
 		posts = append(posts, p)
 	}
 	return posts, nil
+}
+
+// Update modifies the title and/or content of a post owned by the given user
+func (r *PostRepository) Update(postID, userID string, title, content *string) error {
+	set := []string{}
+	args := []interface{}{}
+	if title != nil {
+		set = append(set, "title = ?")
+		args = append(args, *title)
+	}
+	if content != nil {
+		set = append(set, "content = ?")
+		args = append(args, *content)
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	set = append(set, "updated_at = ?")
+	args = append(args, time.Now(), postID, userID)
+	query := fmt.Sprintf("UPDATE posts SET %s WHERE post_id = ? AND user_id = ?", strings.Join(set, ", "))
+	_, err := r.db.Exec(query, args...)
+	return err
 }
 
 // func (r *PostRepository) GetPostsReactedByUser(userID string) ([]models.PostWithUser, error) {

--- a/API/routes/routes.go
+++ b/API/routes/routes.go
@@ -83,6 +83,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 
 	// Protected user routes
 	mux.Handle("/forum/api/posts/create", protected(http.HandlerFunc(postHandler.CreatePost)))
+	mux.Handle("/forum/api/posts/update", protected(http.HandlerFunc(postHandler.UpdatePost)))
 	mux.Handle("/forum/api/user/posts", protected(http.HandlerFunc(myPostsHandler.GetMyPosts)))
 	mux.Handle("/forum/api/user/reactions", protected(http.HandlerFunc(reactionPostsHandler.GetLikedPosts)))
 	mux.Handle("/forum/api/user/comments", protected(http.HandlerFunc(myCommentsHandler.GetMyComments)))

--- a/ui/cmd/main.go
+++ b/ui/cmd/main.go
@@ -106,6 +106,12 @@ func router(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		http.ServeFile(w, r, "./static/templates/user/user_post.html")
+	case "/user/edit_post":
+		if ok, _ := checkSession(r); !ok {
+			http.Redirect(w, r, "/login", http.StatusFound)
+			return
+		}
+		http.ServeFile(w, r, "./static/templates/user/user_edit_post.html")
 	case "/user/my-reactions":
 		if ok, _ := checkSession(r); !ok {
 			http.Redirect(w, r, "/login", http.StatusFound)

--- a/ui/static/css/user_edit_post.css
+++ b/ui/static/css/user_edit_post.css
@@ -1,0 +1,27 @@
+.edit-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin-left: 0.5em;
+  font-size: 0.9em;
+  color: #888;
+}
+
+.edit-btn:hover {
+  color: #fff;
+}
+
+.post-image-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.image-edit {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background: rgba(0,0,0,0.5);
+  color: #fff;
+  border-radius: 4px;
+  padding: 2px 4px;
+}

--- a/ui/static/js/user/user_edit_post.js
+++ b/ui/static/js/user/user_edit_post.js
@@ -1,0 +1,514 @@
+const params = new URLSearchParams(window.location.search);
+const postId = params.get('id');
+const highlightId = params.get('highlight');
+const lastReactions = new Map(); // key = `${type}:${id}`, value = 1 (like) or 2 (dislike)
+
+
+const postContainer = document.getElementById('postContainer');
+
+let currentPost = null;
+
+// CSRF token in-memory storage
+let csrfTokenFromResponse = null;
+
+const sessionVerifyURL = 'http://localhost:8080/forum/api/session/verify';
+
+// Utility: load CSRF token by verifying session
+async function loadCSRFTokenFromSession() {
+  try {
+    const resp = await fetch(sessionVerifyURL, {
+      credentials: 'include',
+    });
+    if (!resp.ok) throw new Error('Session not valid');
+    const data = await resp.json();
+    return data.csrf_token || data.CSRFToken; // Adjust key if needed
+  } catch (err) {
+    console.warn("Failed to load CSRF token from session:", err);
+    return null;
+  }
+}
+
+// Fetch post feed and find the single post by id
+async function loadPost() {
+  if (!postId) {
+    postContainer.textContent = 'Post ID missing.';
+    return;
+  }
+
+  try {
+    const resp = await fetch('http://localhost:8080/forum/api/feed', {
+      credentials: 'include',
+    });
+
+    if (!resp.ok) throw new Error('Failed to load post');
+
+    const data = await resp.json();
+    const posts = mergePostsFromCategories(data.categories || []);
+    const post = posts.find(p => p.id === postId);
+
+    if (!post) {
+      postContainer.textContent = 'Post not found.';
+      return;
+    }
+
+    renderSinglePost(post);
+  } catch (err) {
+    console.error(err);
+    postContainer.textContent = 'Error loading post.';
+  }
+}
+
+// Render the post with interactive like/dislike buttons & comments
+function renderSinglePost(post) {
+  postContainer.innerHTML = '';
+
+  currentPost = post;
+
+  const title = document.createElement('h1');
+  title.className = 'post-title';
+  title.textContent = post.title || 'Untitled';
+  const editTitleBtn = document.createElement('button');
+  editTitleBtn.textContent = '✏️';
+  editTitleBtn.className = 'edit-btn';
+  editTitleBtn.addEventListener('click', async () => {
+    const val = prompt('Edit title', currentPost.title);
+    if (val !== null && val.trim() !== '' && val !== currentPost.title) {
+      await updatePost({ title: val.trim() });
+    }
+  });
+  const titleContainer = document.createElement('div');
+  titleContainer.appendChild(title);
+  titleContainer.appendChild(editTitleBtn);
+
+  const meta = document.createElement('div');
+  meta.className = 'post-meta';
+  meta.textContent = `By ${post.username || post.user_id || 'Unknown'} on ${new Date(post.created_at).toLocaleString()}`;
+
+  const content = document.createElement('div');
+  content.className = 'post-content';
+  content.textContent = post.content || '';
+  const editContentBtn = document.createElement('button');
+  editContentBtn.textContent = '✏️';
+  editContentBtn.className = 'edit-btn';
+  editContentBtn.addEventListener('click', async () => {
+    const val = prompt('Edit content', currentPost.content);
+    if (val !== null && val.trim() !== '' && val !== currentPost.content) {
+      await updatePost({ content: val.trim() });
+    }
+  });
+
+  let imageEl = null;
+  if (post.image_url) {
+    imageEl = document.createElement('img');
+    imageEl.src = post.image_url;
+    imageEl.className = 'post-image';
+    const imgWrapper = document.createElement('div');
+    imgWrapper.className = 'post-image-wrapper';
+    const editImgBtn = document.createElement('button');
+    editImgBtn.textContent = '✏️';
+    editImgBtn.className = 'edit-btn image-edit';
+    editImgBtn.addEventListener('click', () => {
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = 'image/*';
+      input.onchange = async () => {
+        if (!input.files.length) return;
+        if (!csrfTokenFromResponse) {
+          csrfTokenFromResponse = await loadCSRFTokenFromSession();
+          if (!csrfTokenFromResponse) return alert('Session expired');
+        }
+        const fd = new FormData();
+        fd.append('post_id', currentPost.id);
+        fd.append('image', input.files[0]);
+        const resp = await fetch('http://localhost:8080/forum/api/images/upload', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'X-CSRF-Token': csrfTokenFromResponse },
+          body: fd,
+        });
+        if (resp.ok) {
+          location.reload();
+        } else {
+          alert('Image upload failed');
+        }
+      };
+      input.click();
+    });
+    imgWrapper.appendChild(imageEl);
+    imgWrapper.appendChild(editImgBtn);
+    imageEl = imgWrapper;
+  }
+
+  // Wrap post content in a card
+  const postContentCard = document.createElement('div');
+  postContentCard.className = 'post-content-card';
+  postContentCard.appendChild(content);
+  postContentCard.appendChild(editContentBtn);
+
+  // Reactions container with interactive buttons
+  const reactions = document.createElement('div');
+  reactions.className = 'post-reactions';
+
+  // Count likes & dislikes
+  let likes = post.reactions?.filter(r => r.reaction_type === 1).length || 0;
+  let dislikes = post.reactions?.filter(r => r.reaction_type === 2).length || 0;
+
+  const likeBtn = document.createElement('button');
+  likeBtn.textContent = `▲ ${likes}`;
+  likeBtn.className = 'like-btn';
+  likeBtn.title = 'Like';
+
+  const dislikeBtn = document.createElement('button');
+  dislikeBtn.textContent = `▼ ${dislikes}`;
+  dislikeBtn.className = 'dislike-btn';
+  dislikeBtn.title = 'Dislike';
+
+  reactions.appendChild(likeBtn);
+  reactions.appendChild(dislikeBtn);
+
+  const commentCount =
+    post.comment_count || (post.comments ? post.comments.length : 0);
+  const commentCounter = document.createElement('span');
+  commentCounter.className = 'comment-count';
+  commentCounter.textContent = `💬 ${commentCount}`;
+  reactions.appendChild(commentCounter);
+
+  // Reaction button click handlers
+  likeBtn.addEventListener('click', () => handleReaction(post.id, 'post', 1, likeBtn, dislikeBtn));
+  dislikeBtn.addEventListener('click', () => handleReaction(post.id, 'post', 2, likeBtn, dislikeBtn));
+
+  // Categories
+  const categoryEl = document.createElement('div');
+  categoryEl.className = 'post-categories';
+  categoryEl.innerHTML = `<span class="Posted-on-text">Posted on the </span>`;
+  post.categories?.forEach((cat, idx) => {
+    const a = document.createElement('a');
+    a.href = `/user/category?id=${encodeURIComponent(cat.id)}`;
+    a.textContent = cat.name;
+    a.className = 'post-category-link';
+    categoryEl.appendChild(a);
+    if (idx < post.categories.length - 1) {
+      categoryEl.appendChild(document.createTextNode(', '));
+    }
+  });
+
+  // Comments Section
+  const commentSection = document.createElement('div');
+  commentSection.className = 'comments-section';
+
+  const commentHeader = document.createElement('h3');
+  commentHeader.textContent = 'Comments';
+  commentSection.appendChild(commentHeader);
+
+  // Inline Comment Form (no modal, always visible)
+  const commentFormContainer = document.createElement('div');
+  commentFormContainer.className = 'comment-form-container';
+
+  const commentForm = document.createElement('form');
+  commentForm.className = 'comment-form';
+  commentForm.autocomplete = 'off';
+
+  const commentTextarea = document.createElement('textarea');
+  commentTextarea.className = 'comment-textarea';
+  commentTextarea.placeholder = "Write your comment...";
+  commentTextarea.required = true;
+  commentTextarea.rows = 3;
+  commentTextarea.maxLength = 1000;
+
+  const submitCommentBtn = document.createElement('button');
+  submitCommentBtn.type = 'submit';
+  submitCommentBtn.className = 'submit-comment-btn';
+  submitCommentBtn.textContent = 'Submit Comment';
+
+  // Error message element for comment form
+  const errorMsg = document.createElement('div');
+  errorMsg.className = 'comment-error-msg';
+
+  // Character count element
+  const charCount = document.createElement('div');
+  charCount.className = 'comment-char-count';
+  charCount.textContent = '0 / 1000';
+
+  // Update character count on input
+  commentTextarea.addEventListener('input', () => {
+    charCount.textContent = `${commentTextarea.value.length} / 1000`;
+    if (commentTextarea.value.length > 1000) {
+      commentTextarea.value = commentTextarea.value.slice(0, 1000);
+    }
+    errorMsg.classList.remove('visible');
+  });
+
+  // Insert elements in the form
+  commentForm.appendChild(errorMsg);
+  commentForm.appendChild(commentTextarea);
+  commentForm.appendChild(charCount);
+  commentForm.appendChild(submitCommentBtn);
+
+  // Submit comment handler (with validation)
+  commentForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const content = commentTextarea.value.trim();
+    if (!content) {
+      errorMsg.textContent = 'Comment cannot be empty.';
+      errorMsg.classList.add('visible');
+      return;
+    }
+    if (content.length > 1000) {
+      errorMsg.textContent = 'Comment cannot exceed 1000 characters.';
+      errorMsg.classList.add('visible');
+      return;
+    }
+    errorMsg.classList.remove('visible');
+    if (!csrfTokenFromResponse) {
+      csrfTokenFromResponse = await loadCSRFTokenFromSession();
+      if (!csrfTokenFromResponse) {
+        alert('Session expired or not authenticated. Please log in again.');
+        return;
+      }
+    }
+    submitCommentBtn.disabled = true;
+    submitCommentBtn.textContent = 'Submitting...';
+    try {
+      const resp = await fetch('http://localhost:8080/forum/api/comments/create', {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfTokenFromResponse,
+        },
+        body: JSON.stringify({
+          post_id: post.id,
+          content,
+        }),
+      });
+      if (!resp.ok) {
+        const errData = await resp.json().catch(() => ({}));
+        errorMsg.textContent = 'Error: ' + (errData.message || 'Could not submit comment.');
+        errorMsg.classList.add('visible');
+        return;
+      }
+      commentTextarea.value = '';
+      errorMsg.classList.remove('visible');
+      await loadPost();
+    } catch (err) {
+      console.error('Failed to submit comment:', err);
+      errorMsg.textContent = 'Failed to submit comment. Try again later.';
+      errorMsg.classList.add('visible');
+    } finally {
+      submitCommentBtn.disabled = false;
+      submitCommentBtn.textContent = 'Submit Comment';
+    }
+  });
+
+  commentFormContainer.appendChild(commentForm);
+
+  // Comments list
+  if (post.comments?.length > 0) {
+    post.comments.forEach(comment => {
+      commentSection.appendChild(createCommentElement(comment, highlightId));
+    });
+  } else {
+    const noComments = document.createElement('p');
+    noComments.textContent = 'No comments yet.';
+    noComments.className = 'no-comments';
+    commentSection.appendChild(noComments);
+  }
+
+  // Create a boxed post container
+  const postBox = document.createElement('div');
+  postBox.className = 'post';
+
+  postBox.appendChild(titleContainer);
+  postBox.appendChild(meta);
+   if (imageEl) postBox.appendChild(imageEl);
+  postBox.appendChild(postContentCard); // instead of content
+  postBox.appendChild(reactions);
+  postBox.appendChild(categoryEl);
+  postBox.appendChild(commentFormContainer);
+  postBox.appendChild(commentSection);
+
+  // Add everything to the DOM
+  postContainer.appendChild(postBox);
+}
+
+// Helper: create comment element with reactions
+function createCommentElement(comment, highlight) {
+  // Match guest style: compact, simple, but keep interactive buttons
+  const commentEl = document.createElement('div');
+  commentEl.className = 'comment';
+  commentEl.id = `comment-${comment.id}`;
+  if (highlight && comment.id === highlight) {
+    commentEl.classList.add('highlight-comment');
+    setTimeout(() => commentEl.scrollIntoView({ behavior: 'smooth', block: 'center' }), 0);
+  }
+
+  const commentUser = document.createElement('strong');
+  commentUser.textContent = comment.username || comment.user_id || 'Anonymous';
+
+  const commentTime = document.createElement('time');
+  commentTime.textContent = ` (${new Date(comment.created_at).toLocaleString()})`;
+
+  const commentContent = document.createElement('div');
+  commentContent.textContent = comment.content || '';
+
+  // Reactions: visually match guest (inline, compact, no extra box)
+  const commentReactions = document.createElement('div');
+  commentReactions.className = 'comment-reactions';
+
+  const likeCount = comment.reactions?.filter(r => r.reaction_type === 1).length || 0;
+  const dislikeCount = comment.reactions?.filter(r => r.reaction_type === 2).length || 0;
+
+  const likeBtn = document.createElement('button');
+  likeBtn.textContent = `▲ ${likeCount}`;
+  likeBtn.className = 'like-btn';
+  likeBtn.title = 'Like';
+
+  const dislikeBtn = document.createElement('button');
+  dislikeBtn.textContent = `▼ ${dislikeCount}`;
+  dislikeBtn.className = 'dislike-btn';
+  dislikeBtn.title = 'Dislike';
+
+  // Attach handlers for comment reactions (keep interactive)
+  likeBtn.addEventListener('click', () => handleReaction(comment.id, 'comment', 1, likeBtn, dislikeBtn));
+  dislikeBtn.addEventListener('click', () => handleReaction(comment.id, 'comment', 2, likeBtn, dislikeBtn));
+
+  commentReactions.appendChild(likeBtn);
+  commentReactions.appendChild(dislikeBtn);
+
+  // Layout: username, time, content, reactions (all compact)
+  commentEl.appendChild(commentUser);
+  commentEl.appendChild(commentTime);
+  commentEl.appendChild(commentContent);
+  commentEl.appendChild(commentReactions);
+
+  return commentEl;
+}
+
+// Handle like/dislike interaction
+async function handleReaction(targetId, targetType, reactionType, likeBtn, dislikeBtn) {
+  const key = `${targetType}:${targetId}`;
+  const prevReaction = lastReactions.get(key);
+
+  let finalReactionType = reactionType;
+
+  // If clicking same reaction again, it means "remove reaction"
+  const isRemoving = prevReaction === reactionType;
+  if (isRemoving) {
+    finalReactionType = 3; // Special type = remove
+  }
+
+  if (!csrfTokenFromResponse) {
+    csrfTokenFromResponse = await loadCSRFTokenFromSession();
+    if (!csrfTokenFromResponse) {
+      alert('Session expired. Please log in again.');
+      return;
+    }
+  }
+
+  likeBtn.disabled = true;
+  dislikeBtn.disabled = true;
+
+  try {
+    const resp = await fetch('http://localhost:8080/forum/api/react', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrfTokenFromResponse,
+      },
+      body: JSON.stringify({
+        target_id: targetId,
+        target_type: targetType,
+        reaction_type: finalReactionType,
+      }),
+    });
+
+    if (!resp.ok) {
+      const errData = await resp.json().catch(() => ({}));
+      throw new Error(errData.message || 'Failed to react');
+    }
+
+    const reactions = await resp.json();
+    const likes = reactions.filter(r => r.reaction_type === 1).length;
+    const dislikes = reactions.filter(r => r.reaction_type === 2).length;
+
+    likeBtn.textContent = `▲ ${likes}`;
+    dislikeBtn.textContent = `▼ ${dislikes}`;
+
+    // Update local reaction state
+    if (finalReactionType === 3) {
+      lastReactions.delete(key); // removed
+    } else {
+      lastReactions.set(key, reactionType); // updated
+    }
+
+  } catch (err) {
+    console.error(err);
+    alert('Error: ' + err.message);
+  } finally {
+    likeBtn.disabled = false;
+  dislikeBtn.disabled = false;
+  }
+}
+
+async function updatePost(data) {
+  if (!csrfTokenFromResponse) {
+    csrfTokenFromResponse = await loadCSRFTokenFromSession();
+    if (!csrfTokenFromResponse) {
+      alert('Session expired. Please log in again.');
+      return;
+    }
+  }
+
+  try {
+    const resp = await fetch('http://localhost:8080/forum/api/posts/update', {
+      method: 'PUT',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrfTokenFromResponse,
+      },
+      body: JSON.stringify({ post_id: currentPost.id, ...data }),
+    });
+
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      alert(err.message || 'Failed to update post');
+      return;
+    }
+
+    if (data.title) currentPost.title = data.title;
+    if (data.content) currentPost.content = data.content;
+    renderSinglePost(currentPost);
+  } catch (err) {
+    console.error('update failed', err);
+    alert('Failed to update post');
+  }
+}
+
+
+
+// Helper: merge posts from categories (same as your original)
+function mergePostsFromCategories(categories) {
+  const postsMap = new Map();
+  categories.forEach(category => {
+    const categoryId = category.id;
+    const categoryName = category.name;
+
+    category.posts.forEach(post => {
+      if (!postsMap.has(post.id)) {
+        postsMap.set(post.id, {
+          ...post,
+          categories: [{ id: categoryId, name: categoryName }],
+        });
+      } else {
+        const existing = postsMap.get(post.id);
+        existing.categories.push({ id: categoryId, name: categoryName });
+      }
+    });
+  });
+  return Array.from(postsMap.values());
+}
+
+// Initial load
+loadPost();

--- a/ui/static/js/user/user_my_posts.js
+++ b/ui/static/js/user/user_my_posts.js
@@ -64,7 +64,7 @@ function renderCreatedPosts(posts) {
       .parentNode.appendChild(commentContainer);
 
     const wrapper = document.createElement('a');
-    wrapper.href = `/user/post?id=${post.id}`;
+    wrapper.href = `/user/edit_post?id=${post.id}`;
     wrapper.className = 'post-link';
     wrapper.appendChild(node);
 

--- a/ui/static/templates/user/user_edit_post.html
+++ b/ui/static/templates/user/user_edit_post.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Edit Post</title>
+  <link rel="stylesheet" href="/static/css/user.css" />
+  <link rel="stylesheet" href="/static/css/user_post.css" />
+  <link rel="stylesheet" href="/static/css/user_edit_post.css" />
+</head>
+<body>
+  <nav class="navbar">
+    <a class="navbar-brand" href="/user/feed">Forum</a>
+  </nav>
+
+  <main class="post-container" id="postContainer">
+    Loading post...
+  </main>
+
+  <script type="module" src="/static/js/user/user_edit_post.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add backend endpoint to update post title/content
- implement repository method to handle updates
- expose new API route and UI route
- create edit page with pencil icons for editing each section
- open posts from My Posts in edit mode

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_688242e6437083248010afe225ab3c05