### PR TITLE
Fix my posts navigation

### DIFF
--- a/ui/static/js/user/user_activity.js
+++ b/ui/static/js/user/user_activity.js
@@ -77,7 +77,7 @@ function renderPosts(posts) {
     node.querySelector('.post-content').textContent = p.content;
     node.querySelector('.post-time').textContent = new Date(p.created_at).toLocaleString();
     const wrapper = document.createElement('a');
-    wrapper.href = `/user/post?id=${p.id}`;
+    wrapper.href = `/user/edit_post?id=${p.id}`;
     wrapper.className = 'post-link';
     wrapper.appendChild(node);
     container.appendChild(wrapper);


### PR DESCRIPTION
## Summary
- ensure posts listed in the Activity > My Posts tab link to the edit page instead of the read-only view

## Testing
- `go build ./API/...`
- `go build -o /tmp/ui_server ./ui/cmd`
- `go vet ./ui/...`

------
https://chatgpt.com/codex/tasks/task_e_688246ac0e888324a49a44aebec51dc0